### PR TITLE
Fix .getArmour() in 1.21.5 and upwards

### DIFF
--- a/EZMount.lua
+++ b/EZMount.lua
@@ -71,7 +71,7 @@ local function getMount(name)
 end
 
 local function getArmor(entity)
-    return entity.body_armor_item or entity.ArmorItems[3]
+    return (entity.equipment ~= nil and entity.equipment or entity.equipment[3] or entity.body_armor_item or entity.ArmorItems[3])
 end
 
 local textGuide = '§f\nlocal textureTable  = {\n    iron = textures["reference"],\n    diamond = textures["reference"],\n    golden = textures["reference"],\n    leather = textures["reference"]\n}\n'..
@@ -247,3 +247,4 @@ function mounts:newObjectMount(id,modelpart,passenger,anim)
 end
 
 return mounts
+

--- a/EZMount.lua
+++ b/EZMount.lua
@@ -71,7 +71,11 @@ local function getMount(name)
 end
 
 local function getArmor(entity)
-    return (entity.equipment ~= nil and entity.equipment or entity.equipment[3] or entity.body_armor_item or entity.ArmorItems[3])
+    if (entity.equipment ~= nil or entity.body_armor_item ~= nil) then
+        return (entity.equipment ~= nil and entity.equipment or entity.equipment[3] or entity.body_armor_item or entity.ArmorItems[3])
+    else
+        return {}
+    end
 end
 
 local textGuide = '§f\nlocal textureTable  = {\n    iron = textures["reference"],\n    diamond = textures["reference"],\n    golden = textures["reference"],\n    leather = textures["reference"]\n}\n'..
@@ -247,4 +251,5 @@ function mounts:newObjectMount(id,modelpart,passenger,anim)
 end
 
 return mounts
+
 


### PR DESCRIPTION
for SOME reason mojang (or figura idk) changed the dict name for equipment / armor in 1.21.5 to `entity.equipment` for a more unified table over just `entity.body_armor_item`

this is a quick patch so idk if it'll mess up any compatibility but yeah
that's all, just fixes the script in 1.21+